### PR TITLE
Remove legacy NPM tokens, switch to trusted publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -54,5 +54,3 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - name: Publish to NPM
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
In Mid-November 2025, NPM will [no longer support](https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management/) classic access tokens, which among other things have been used for publishing packages. This is done for [security reasons](https://github.blog/security/supply-chain-security/our-plan-for-a-more-secure-npm-supply-chain/). Instead, it is recommended to switch to trusted publishing. This requires [adjustments](https://docs.npmjs.com/trusted-publishers) to existing GitHub Actions workflows. This PR implements the necessary changes:
- Ensure the `id-token: write` permission is granted, so that [OIDC tokens](https://docs.github.com/en/actions/concepts/security/openid-connect) can be generated
- Remove the `NODE_AUTH_TOKEN` environment variable form the workflow